### PR TITLE
Fix font not being loaded

### DIFF
--- a/lua/autorun/sv_adder.lua
+++ b/lua/autorun/sv_adder.lua
@@ -3,6 +3,6 @@ if SERVER then
 	AddCSLuaFile("/terrortown/gamemode/cl_hud")
 	AddCSLuaFile("/terrortown/gamemode/cl_hudpickup")
 	AddCSLuaFile("/terrortown/gamemode/cl_wepswitch")
-	resource.AddFile("resource/fonts/octin_sports_rg.tff")
+	resource.AddFile("resource/fonts/octin_sports_rg.ttf")
 end
 


### PR DESCRIPTION
Due to a typo, the custom font file wasn't downloaded by clients.