### PR TITLE
Hotfix 21012020 Update

### DIFF
--- a/lua/terrortown/gamemode/cl_wepswitch.lua
+++ b/lua/terrortown/gamemode/cl_wepswitch.lua
@@ -300,7 +300,7 @@ function WSWITCH:ConfirmSelection(noHide)
 
 	for k, w in pairs(self.WeaponCache) do
 		if k == self.Selected and IsValid(w) then
-			RunConsoleCommand("wepswitch", w:GetClass())
+				input.SelectWeapon(w)
 			return
 		end
 	end


### PR DESCRIPTION
Fixes an error introduced by the 21.01.2020 Update of Garry's mod.
The wepswitch command is obsoleted and got replaced by ``input.SelectWeapon(w)``